### PR TITLE
Read settings from environment variables when not configured elsewhere

### DIFF
--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -13,6 +13,8 @@ using System.Text.RegularExpressions;
 
 namespace LogentriesCore.Net
 {
+    using System.Security;
+
     public class AsyncLogger
     {
         #region Constants
@@ -460,11 +462,26 @@ namespace LogentriesCore.Net
 
         private string retrieveSetting(String name)
         {
+            string value;
+
 #if NET4_0
-            return CloudConfigurationManager.GetSetting(name);
+            value = CloudConfigurationManager.GetSetting(name);
 #else
-            return ConfigurationManager.AppSettings[name];
+            value = ConfigurationManager.AppSettings[name];
 #endif
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                try
+                {
+                    value = Environment.GetEnvironmentVariable(name);
+                }
+                catch (SecurityException)
+                {
+                }
+            }
+
+            return value;
         }
 
         /*


### PR DESCRIPTION
We're using logentries in a system where we try to keep configuration out of the file system and in the environment (à la [the twelve-factor app](http://12factor.net/config)).

This PR changes the "load settings" step such that, if a setting isn't configured in `Web.config` or `App.config` (or Service Configuration for Azure applications), then it's read from the environment variables.
