### PR TITLE
Fix build when NET4_0 symbol is defined

### DIFF
--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -6,9 +6,10 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
-
-#if !NET4_0
 using System.Text.RegularExpressions;
+
+#if NET4_0
+using Microsoft.WindowsAzure;
 #endif
 
 namespace LogentriesCore.Net
@@ -553,7 +554,7 @@ namespace LogentriesCore.Net
 
             System.Guid newGuid = System.Guid.NewGuid();
 #if NET4_0
-            return System.Guid.TryParse(uuid_input, out newGuid);
+            return System.Guid.TryParse(guidString, out newGuid);
 #else
             return IsGuid(guidString, out newGuid);
 #endif


### PR DESCRIPTION
The build was broken when the custom `NET4_0` symbol was defined:
- there was a typo in a variable name
- a couple of required using statements were missing

This problem seems to have been here from [the beginning](https://github.com/logentries/le_dotnet/commit/6017a8be0a3538e9e1dfdeda543b457aaaf40a52) so I'm not sure if the `NET4_0` symbol is actually used/needed. Without it defined the support for [`CloudConfigurationManager`](http://msdn.microsoft.com/en-us/library/microsoft.windowsazure.cloudconfigurationmanager.aspx) wouldn't work, so there's a good chance this is the root of #1
