### PR TITLE
Change ports for tcp(tls)/tcp to standard 80/443

### DIFF
--- a/src/LogentriesCore/AsyncLogger.cs
+++ b/src/LogentriesCore/AsyncLogger.cs
@@ -17,7 +17,7 @@ namespace LogentriesCore.Net
     using System.Security;
     using System.Collections.Concurrent;
     using Microsoft.Azure;
-    
+
     public class AsyncLogger
     {
         #region Constants
@@ -25,19 +25,19 @@ namespace LogentriesCore.Net
         // Current version number.
         protected const String Version = "2.6.7";
 
-        // Size of the internal event queue. 
+        // Size of the internal event queue.
         protected const int QueueSize = 32768;
 
-        // Minimal delay between attempts to reconnect in milliseconds. 
+        // Minimal delay between attempts to reconnect in milliseconds.
         protected const int MinDelay = 100;
 
-        // Maximal delay between attempts to reconnect in milliseconds. 
+        // Maximal delay between attempts to reconnect in milliseconds.
         protected const int MaxDelay = 10000;
 
-        // Appender signature - used for debugging messages. 
+        // Appender signature - used for debugging messages.
         protected const String LeSignature = "LE: ";
 
-        // Legacy Logentries configuration names. 
+        // Legacy Logentries configuration names.
         protected const String LegacyConfigTokenName = "LOGENTRIES_TOKEN";
         protected const String LegacyConfigAccountKeyName = "LOGENTRIES_ACCOUNT_KEY";
         protected const String LegacyConfigLocationName = "LOGENTRIES_LOCATION";
@@ -47,16 +47,16 @@ namespace LogentriesCore.Net
         protected const String ConfigAccountKeyName = "Logentries.AccountKey";
         protected const String ConfigLocationName = "Logentries.Location";
 
-        // Error message displayed when invalid token is detected. 
+        // Error message displayed when invalid token is detected.
         protected const String InvalidTokenMessage = "\n\nIt appears your LOGENTRIES_TOKEN value is invalid or missing.\n\n";
 
-        // Error message displayed when invalid account_key or location parameters are detected. 
+        // Error message displayed when invalid account_key or location parameters are detected.
         protected const String InvalidHttpPutCredentialsMessage = "\n\nIt appears your LOGENTRIES_ACCOUNT_KEY or LOGENTRIES_LOCATION values are invalid or missing.\n\n";
 
-        // Error message deisplayed when queue overflow occurs. 
+        // Error message deisplayed when queue overflow occurs.
         protected const String QueueOverflowMessage = "\n\nLogentries buffer queue overflow. Message dropped.\n\n";
 
-        // Newline char to trim from message for formatting. 
+        // Newline char to trim from message for formatting.
         protected static char[] TrimChars = { '\r', '\n' };
 
         /** Non-Unix and Unix Newline */
@@ -73,10 +73,10 @@ namespace LogentriesCore.Net
 
         #region Singletons
 
-        // UTF-8 output character set. 
+        // UTF-8 output character set.
         protected static readonly UTF8Encoding UTF8 = new UTF8Encoding();
 
-        // ASCII character set used by HTTP. 
+        // ASCII character set used by HTTP.
         protected static readonly ASCIIEncoding ASCII = new ASCIIEncoding();
 
         //static list of all the queues the le appender might be managing.
@@ -312,7 +312,7 @@ namespace LogentriesCore.Net
                         }
                     }
                 }
-                            
+
                 if (m_LogID != String.Empty)
                 {
                     logMessagePrefix = m_LogID + " ";
@@ -346,7 +346,7 @@ namespace LogentriesCore.Net
                     // If m_UseDataHub == true (logs are sent to DataHub instance) then m_Token is not
                     // appended to the message.
                     string finalLine = ((!m_UseDataHub) ? this.m_Token + line : line) + '\n';
-                    
+
                     // Add prefixes: LogID and HostName if they are defined.
                     if (!isPrefixEmpty)
                     {
@@ -398,10 +398,10 @@ namespace LogentriesCore.Net
                 if (LeClient == null)
                 {
                     // Create LeClient instance providing all needed parameters. If DataHub-related properties
-                    // have not been overridden by log4net or NLog configurators, then DataHub is not used, 
+                    // have not been overridden by log4net or NLog configurators, then DataHub is not used,
                     // because m_UseDataHub == false by default.
                     LeClient = new LeClient(m_UseSsl, m_UseDataHub, m_DataHubAddr, m_DataHubPort);
-                }                    
+                }
 
                 LeClient.Connect();
             }
@@ -470,7 +470,7 @@ namespace LogentriesCore.Net
 
         /* Retrieve configuration settings
          * Will check Enviroment Variable as the last fall back.
-         * 
+         *
          */
         private string retrieveSetting(String name)
         {
@@ -485,7 +485,7 @@ namespace LogentriesCore.Net
             }
 
 
-            
+
             if (!String.IsNullOrWhiteSpace(cloudconfig))
             {
                 WriteDebugMessages(String.Format("Found Cloud Configuration settings for {0}", name));
@@ -511,13 +511,13 @@ namespace LogentriesCore.Net
 
         /*
          * Use CloudConfigurationManager with .NET4.0 and fallback to System.Configuration for previous frameworks.
-         * 
-         *       
+         *
+         *
          *       One issue is that there are two appsetting keys for each setting - the "legacy" key, such as "LOGENTRIES_TOKEN"
          *       and the "non-legacy" key, such as "Logentries.Token".  Again, I'm not sure of the reasons behind this, so the code below checks
          *       both the legacy and non-legacy keys, defaulting to the legacy keys if they are found.
-         *       
-         *       It probably should be investigated whether the fallback to ConfigurationManager is needed at all, as CloudConfigurationManager 
+         *
+         *       It probably should be investigated whether the fallback to ConfigurationManager is needed at all, as CloudConfigurationManager
          *       will retrieve settings from appSettings in a non-Azure environment.
          */
         public virtual bool LoadCredentials()

--- a/src/LogentriesCore/LeClient.cs
+++ b/src/LogentriesCore/LeClient.cs
@@ -12,10 +12,10 @@ namespace LogentriesCore.Net
         protected const String LeIngestionHost = "data.logentries.com";
 
         // Port number for token logging on Logentries API server.
-        protected const int LeApiTokenPort = 10000;
+        protected const int LeApiTokenPort = 80;
 
         // Port number for TLS encrypted token logging on Logentries API server
-        protected const int LeApiTokenTlsPort = 20000;
+        protected const int LeApiTokenTlsPort = 443;
 
         // Creates LeClient instance. If do not define useServerUrl and/or useOverrideProt during call
         // LeClient will be configured to work with data.logentries.com server; otherwise - with


### PR DESCRIPTION
Change ports for tcp(tls)/tcp to standard 80/443 to match opsight client. https://github.com/rapid7/r7insight_dotnet/blob/master/src/R7InsightCore/InsightClient.cs#L15-L18

V3 release broke all outbound logging as it uses non-standard port-ranges contrary to the serilog provider (https://github.com/serilog/serilog-sinks-logentries/blob/dev/src/Serilog.Sinks.Logentries/Sinks/Logentries/LeClient.cs#L48-L51) and previous iteration of the LE sink.