### PR TITLE
LOG-19529 Adding github team name to codeowners file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@logsearch-splinter
+* @rapid7/dublin-splinter

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+@logsearch-splinter


### PR DESCRIPTION
## Issue

Link to Jira ticket:  [LOG-19529](https://issues.corp.rapid7.com/browse/LOG-19529)

## Purpose of PR

Add splinter team to codeowners file